### PR TITLE
Fix inverse token mask concatenation error and add support for mps devices

### DIFF
--- a/bert/dataset.py
+++ b/bert/dataset.py
@@ -194,7 +194,7 @@ class IMDBBertDataset(Dataset):
         return sentences[sentence_index], sentences[next_sentence_index]
 
     def _preprocess_sentence(self, sentence: typing.List[str], should_mask: bool = True):
-        inverse_token_mask = None
+        inverse_token_mask = []
         if should_mask:
             sentence, inverse_token_mask = self._mask_sentence(sentence)
         sentence, inverse_token_mask = self._pad_sentence([self.CLS] + sentence, [True] + inverse_token_mask)

--- a/bert/dataset.py
+++ b/bert/dataset.py
@@ -13,7 +13,7 @@ from torchtext.vocab import vocab
 from torchtext.data.utils import get_tokenizer
 
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else ("mps" if torch.backends.mps.is_available() else "cpu"))
 
 
 class IMDBBertDataset(Dataset):

--- a/bert/model.py
+++ b/bert/model.py
@@ -4,7 +4,7 @@ from torch import nn
 import torch.nn.functional as f
 
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else ("mps" if torch.backends.mps.is_available() else "cpu"))
 
 
 class JointEmbedding(nn.Module):

--- a/bert/trainer.py
+++ b/bert/trainer.py
@@ -11,7 +11,7 @@ from torch.utils.tensorboard import SummaryWriter
 from bert.dataset import IMDBBertDataset
 from bert.model import BERT
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else ("mps" if torch.backends.mps.is_available() else "cpu"))
 
 
 def percentage(batch_size: int, max_index: int, current_index: int):

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ CHECKPOINT_DIR = BASE_DIR.joinpath('data/bert_checkpoints')
 timestamp = datetime.datetime.utcnow().timestamp()
 LOG_DIR = BASE_DIR.joinpath(f'data/logs/bert_experiment_{timestamp}')
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = torch.device("cuda" if torch.cuda.is_available() else ("mps" if torch.backends.mps.is_available() else "cpu"))
 
 if torch.cuda.is_available():
     torch.cuda.empty_cache()


### PR DESCRIPTION
Thank you for your great work and generous contribution. During my reimplementation of your work I have noticed the following error:


in `/bert/dataset.py`, at line 197 in method `_preprocess_sentence()`, the default value of `inverse_token_mask` has been set to `None`, which cannot be directly appended to a `List` object. With Python 3.11, running the code will result in the following error:

<img width="694" alt="image" src="https://github.com/coaxsoft/pytorch_bert/assets/60131395/2a71084a-5f16-42ea-99ab-e7f66a830e76">

which can be resolved by replacing the variable's default value as an empty list `[]`.

Having noticed you haven't enabled mps device acceleration support for Apple Silicon devices, I have added support for it as well. It will make full use of Apple Silicon SoCs' GPU for model training and should yields much faster model training speed.
